### PR TITLE
Allow request object to be passed into RequestResponseDispatcher ctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ $router->addRoute('GET', '/users', 'Quimi\Controllers\UserController::index');
 $request = Request::createFromGlobals();
 $route = $router->parse($request->getMethod(), $request->getPathInfo());
 
+// You can optionally modify the request object here before dispatching:
+$request->attributes->set('foo', 'bar');
+
 $dispatcher = new RequestResponseDispatcher($request);
 $response = $dispatcher->handle($route);
 $response->send();

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ $router->addRoute('GET', '/users', 'Quimi\Controllers\UserController::index');
 $request = Request::createFromGlobals();
 $route = $router->parse($request->getMethod(), $request->getPathInfo());
 
-$dispatcher = new RequestResponseDispatcher;
+$dispatcher = new RequestResponseDispatcher($request);
 $response = $dispatcher->handle($route);
 $response->send();
 ```

--- a/src/RequestResponseDispatcher.php
+++ b/src/RequestResponseDispatcher.php
@@ -8,6 +8,21 @@ use RuntimeException;
 class RequestResponseDispatcher implements DispatcherInterface
 {
     /**
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    private $request = null;
+
+    /**
+     * @param Request|null $request
+     */
+    public function __construct(Request $request = null)
+    {
+        if (isset($request)) {
+            $this->request = $request;
+        }
+    }
+
+    /**
      * @param ParsedRoute $route
      * @return Response
      *
@@ -19,11 +34,14 @@ class RequestResponseDispatcher implements DispatcherInterface
         $controller = $segments[0];
         $action = count($segments) > 1 ? $segments[1] : "index";
         if (method_exists($controller, $action)) {
-            $params = [Request::createFromGlobals(), new Response];
+            if (!isset($this->request)) {
+                $this->request = Request::createFromGlobals();
+            }
+            $params = [$this->request, new Response()];
             if (count($route->params())) {
                 $params[] = $route->params();
             }
-            return call_user_func_array([new $controller, $action], $params);
+            return call_user_func_array([new $controller(), $action], $params);
         } else {
             throw new RuntimeException("No method {$action} in controller {$segments[0]}");
         }


### PR DESCRIPTION
I am using the RequestResponseDispatcher, and am encountering a situation in which for certain routes I want to be able to set attributes on the Request object before passing it into the dispatcher:

``` php
$request->attributes->set('AuthorizedUser', $jwtPayload);
```

This patch allows an optional modified Request to be passed into the RequestResponseDispatcher constructor, which the dispatcher will then use instead of creating a new one from globals. If no Request is passed in, then a fresh Request is created; these modifications are therefore totally backwards-compatible.
