### PR TITLE
Add named routes, closes #4

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -81,7 +81,7 @@ class Router
      */
     public function addHead($uri, $handler, $name = null)
     {
-        $this->addRoute("HEAD", $uri, $handler);
+        $this->addRoute("HEAD", $uri, $handler, $name);
     }
 
     /**
@@ -94,7 +94,7 @@ class Router
      */
     public function addGet($uri, $handler, $name = null)
     {
-        $this->addRoute("GET", $uri, $handler);
+        $this->addRoute("GET", $uri, $handler, $name);
     }
 
     /**
@@ -107,7 +107,7 @@ class Router
      */
     public function addDelete($uri, $handler, $name = null)
     {
-        $this->addRoute("DELETE", $uri, $handler);
+        $this->addRoute("DELETE", $uri, $handler, $name);
     }
 
     /**
@@ -120,7 +120,7 @@ class Router
      */
     public function addOptions($uri, $handler, $name = null)
     {
-        $this->addRoute("OPTIONS", $uri, $handler);
+        $this->addRoute("OPTIONS", $uri, $handler, $name);
     }
 
     /**
@@ -133,7 +133,7 @@ class Router
      */
     public function addPatch($uri, $handler, $name = null)
     {
-        $this->addRoute("PATCH", $uri, $handler);
+        $this->addRoute("PATCH", $uri, $handler, $name);
     }
 
     /**
@@ -146,7 +146,7 @@ class Router
      */
     public function addPost($uri, $handler, $name = null)
     {
-        $this->addRoute("POST", $uri, $handler);
+        $this->addRoute("POST", $uri, $handler, $name);
     }
 
     /**
@@ -159,7 +159,7 @@ class Router
      */
     public function addPut($uri, $handler, $name = null)
     {
-        $this->addRoute("PUT", $uri, $handler);
+        $this->addRoute("PUT", $uri, $handler, $name);
     }
 
     /**

--- a/src/Router.php
+++ b/src/Router.php
@@ -5,6 +5,7 @@ class Router
 {
     private $trailing_slash_check = true;
     private $routes = [];
+    private $route_names = [];
     private $regexp_map = [
         '/\{([A-Za-z]\w*)\}/' => '(?<$1>[^/]+)',
         '/\{([A-Za-z]\w*):word\}/' => '(?<$1>\w+)',
@@ -53,9 +54,14 @@ class Router
      * @param string $handler
      *      ClassName::methodName to invoke for this route. If methodName
      *      is not present, a method of 'index' is assumed.
+     * @param string $name
+     *      (Optional) An unique name for this route.
      */
-    public function addRoute($methods, $uri, $handler)
+    public function addRoute($methods, $uri, $handler, $name = null)
     {
+        if (is_string($name) && trim($name) !== "") {
+            $this->route_names[$name] = $uri;
+        }
         foreach ((array)$methods as $method) {
             $method = strtoupper($method);
             if (!isset($this->routes[$method])) {
@@ -70,8 +76,10 @@ class Router
      *
      * @param string $uri
      * @param string $handler
+     * @param string $name
+     *      (Optional) An unique name for this route.
      */
-    public function addHead($uri, $handler)
+    public function addHead($uri, $handler, $name = null)
     {
         $this->addRoute("HEAD", $uri, $handler);
     }
@@ -81,8 +89,10 @@ class Router
      *
      * @param string $uri
      * @param string $handler
+     * @param string $name
+     *      (Optional) An unique name for this route.
      */
-    public function addGet($uri, $handler)
+    public function addGet($uri, $handler, $name = null)
     {
         $this->addRoute("GET", $uri, $handler);
     }
@@ -92,8 +102,10 @@ class Router
      *
      * @param string $uri
      * @param string $handler
+     * @param string $name
+     *      (Optional) An unique name for this route.
      */
-    public function addDelete($uri, $handler)
+    public function addDelete($uri, $handler, $name = null)
     {
         $this->addRoute("DELETE", $uri, $handler);
     }
@@ -103,8 +115,10 @@ class Router
      *
      * @param string $uri
      * @param string $handler
+     * @param string $name
+     *      (Optional) An unique name for this route.
      */
-    public function addOptions($uri, $handler)
+    public function addOptions($uri, $handler, $name = null)
     {
         $this->addRoute("OPTIONS", $uri, $handler);
     }
@@ -114,8 +128,10 @@ class Router
      *
      * @param string $uri
      * @param string $handler
+     * @param string $name
+     *      (Optional) An unique name for this route.
      */
-    public function addPatch($uri, $handler)
+    public function addPatch($uri, $handler, $name = null)
     {
         $this->addRoute("PATCH", $uri, $handler);
     }
@@ -125,8 +141,10 @@ class Router
      *
      * @param string $uri
      * @param string $handler
+     * @param string $name
+     *      (Optional) An unique name for this route.
      */
-    public function addPost($uri, $handler)
+    public function addPost($uri, $handler, $name = null)
     {
         $this->addRoute("POST", $uri, $handler);
     }
@@ -136,8 +154,10 @@ class Router
      *
      * @param string $uri
      * @param string $handler
+     * @param string $name
+     *      (Optional) An unique name for this route.
      */
-    public function addPut($uri, $handler)
+    public function addPut($uri, $handler, $name = null)
     {
         $this->addRoute("PUT", $uri, $handler);
     }
@@ -162,6 +182,28 @@ class Router
     public function addPattern($name, $regexp)
     {
         $this->regexp_map = ['/\{(\w+):'.$name.'\}/' => '(?<$1>'.$regexp.')'] + $this->regexp_map;
+    }
+
+    /**
+     * Finds the uri associated with a given name.
+     *
+     * @param string $name
+     *      Name of the route to find.
+     * @param array $parameters
+     *      (Optional) Parameters to complete the URI.
+     *
+     * @return string|null
+     */
+    public function findURI($name, $parameters = [])
+    {
+        if (array_key_exists($name, $this->route_names)) {
+            $foundUri = $this->route_names[$name];
+            // insert provided parameters on his slot
+            foreach ($parameters as $parameter => $value) {
+                $foundUri = preg_replace("/\{(".$parameter.")(\:\w+)?\}/i", $value, $foundUri);
+            }
+            return $foundUri;
+        }
     }
 
     /**

--- a/tests/ParsedRouteTest.php
+++ b/tests/ParsedRouteTest.php
@@ -6,7 +6,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 
 class ParsedRouteTest extends TestCase
 {
-   public function testConstructor()
+    public function testConstructor()
     {
         $parsedRoute = new ParsedRoute("Vendor\\Package\\{controller}::action", [
             "param1" => 1,

--- a/tests/RequestResponseDispatcherTest.php
+++ b/tests/RequestResponseDispatcherTest.php
@@ -5,6 +5,7 @@ use QuimCalpe\Router\ParsedRoute;
 use QuimCalpe\Router\RequestResponseDispatcher;
 use Vendor\Package\MockControllerRequestResponse as MockController;
 use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 class RequestResponseDispatcherTest extends TestCase
 {
@@ -27,6 +28,15 @@ class RequestResponseDispatcherTest extends TestCase
         $controller = new MockController;
         $dispatcher->handle($parsedRoute);
         $this->assertFalse($controller::$index);
+    }
+
+    public function test_with_constructor()
+    {
+        $dispatcher = new RequestResponseDispatcher(Request::createFromGlobals());
+        $parsedRoute = new ParsedRoute("Vendor\Package\MockControllerRequestResponse::index");
+        $controller = new MockController;
+        $dispatcher->handle($parsedRoute);
+        $this->assertTrue($controller::$index);
     }
 
     public function testEditAction()

--- a/tests/RequestResponseDispatcherTest.php
+++ b/tests/RequestResponseDispatcherTest.php
@@ -3,7 +3,7 @@ namespace QuimCalpe\Router\Router\Test;
 
 use QuimCalpe\Router\ParsedRoute;
 use QuimCalpe\Router\RequestResponseDispatcher;
-use Vendor\Package\MockControllerRequestResponse AS MockController;
+use Vendor\Package\MockControllerRequestResponse as MockController;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class RequestResponseDispatcherTest extends TestCase
@@ -60,10 +60,10 @@ class RequestResponseDispatcherTest extends TestCase
         $parsedRoute = new ParsedRoute("Vendor\Package\MockControllerRequestResponse::nono");
         $dispatcher->handle($parsedRoute);
     }
-
 }
 
 namespace Vendor\Package;
+
 class MockControllerRequestResponse
 {
     public static $index;

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -60,19 +60,19 @@ class RouterTest extends TestCase
     public function testFoundWithParams()
     {
         $router = new Router($this->routes);
-        $resultado = $router->parse("GET", "/segment5/some_controller");
-        $this->assertEquals("Vendor\Package5\{controller}", $resultado->controller());
-        $this->assertEquals("some_controller", $resultado->params()["controller"]);
+        $result = $router->parse("GET", "/segment5/some_controller");
+        $this->assertEquals("Vendor\Package5\{controller}", $result->controller());
+        $this->assertEquals("some_controller", $result->params()["controller"]);
 
-        $resultado = $router->parse("GET", "/segment5/some_controller/some_action");
-        $this->assertEquals("Vendor\Package5\{controller}::{action}", $resultado->controller());
-        $this->assertEquals("some_controller", $resultado->params()["controller"]);
-        $this->assertEquals("some_action", $resultado->params()["action"]);
+        $result = $router->parse("GET", "/segment5/some_controller/some_action");
+        $this->assertEquals("Vendor\Package5\{controller}::{action}", $result->controller());
+        $this->assertEquals("some_controller", $result->params()["controller"]);
+        $this->assertEquals("some_action", $result->params()["action"]);
 
-        $resultado = $router->parse("GET", "/some_package/some_controller");
-        $this->assertEquals("Vendor\{package}\{controller}", $resultado->controller());
-        $this->assertEquals("some_package", $resultado->params()["package"]);
-        $this->assertEquals("some_controller", $resultado->params()["controller"]);
+        $result = $router->parse("GET", "/some_package/some_controller");
+        $this->assertEquals("Vendor\{package}\{controller}", $result->controller());
+        $this->assertEquals("some_package", $result->params()["package"]);
+        $this->assertEquals("some_controller", $result->params()["controller"]);
     }
 
     public function testNotFound()
@@ -167,17 +167,43 @@ class RouterTest extends TestCase
 
         $router->addPattern("phone", "[0-9]-[0-9]{3}-[[0-9]{3}-[0-9]{4}"); // #-###-###-####
 
-        $resultado = $router->parse("GET", "/customer/123");
-        $this->assertEquals("Vendor\Package\Controller", $resultado->controller());
-        $this->assertEquals(123, $resultado->params()["id"]);
+        $result = $router->parse("GET", "/customer/123");
+        $this->assertEquals("Vendor\Package\Controller", $result->controller());
+        $this->assertEquals(123, $result->params()["id"]);
 
-        $resultado = $router->parse("GET", "/customer/John");
-        $this->assertEquals("Vendor\Package\Controller", $resultado->controller());
-        $this->assertEquals("John", $resultado->params()["name"]);
+        $result = $router->parse("GET", "/customer/John");
+        $this->assertEquals("Vendor\Package\Controller", $result->controller());
+        $this->assertEquals("John", $result->params()["name"]);
 
-        $resultado = $router->parse("GET", "/customer/1-222-333-4444");
-        $this->assertEquals("Vendor\Package\Controller", $resultado->controller());
-        $this->assertEquals("1-222-333-4444", $resultado->params()["phone"]);
+        $result = $router->parse("GET", "/customer/1-222-333-4444");
+        $this->assertEquals("Vendor\Package\Controller", $result->controller());
+        $this->assertEquals("1-222-333-4444", $result->params()["phone"]);
     }
 
+    public function test_findURI()
+    {
+        $router = new Router();
+
+        $router->addRoute("GET", "/customer/route1", "Vendor\Package\Controller1", "route1");
+        $router->addRoute("GET", "/customer/route2", "Vendor\Package\Controller2");
+        $this->assertEquals("/customer/route1", $router->findURI("route1"));
+        $this->assertNull($router->findURI("routefoo"));
+    }
+
+    public function test_findURI_with_parameters()
+    {
+        $router = new Router();
+
+        $router->addRoute("GET", "/customer/{id:number}", "Vendor\Package\Controller1", "route1");
+        $this->assertEquals("/customer/123", $router->findURI("route1", ["id" => 123]));
+
+        $router->addRoute("GET", "/customer/{id}/{action}", "Vendor\Package\Controller2", "route2");
+        $this->assertEquals("/customer/123/edit", $router->findURI("route2", [
+            "id" => 123,
+            "action" => "edit"
+        ]));
+
+        $router->addRoute("GET", "/customer/{id}/{action}", "Vendor\Package\Controller2", "route3");
+        $this->assertEquals("/customer/{id}/{action}", $router->findURI("route3"));
+    }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -188,6 +188,9 @@ class RouterTest extends TestCase
         $router->addRoute("GET", "/customer/route2", "Vendor\Package\Controller2");
         $this->assertEquals("/customer/route1", $router->findURI("route1"));
         $this->assertNull($router->findURI("routefoo"));
+
+        $router->addGET("/customer/route3", "Vendor\Package\Controller1", "route3");
+        $this->assertEquals("/customer/route3", $router->findURI("route3"));
     }
 
     public function test_findURI_with_parameters()

--- a/tests/SimpleDispatcherTest.php
+++ b/tests/SimpleDispatcherTest.php
@@ -3,7 +3,7 @@ namespace QuimCalpe\Router\Router\Test;
 
 use QuimCalpe\Router\ParsedRoute;
 use QuimCalpe\Router\SimpleDispatcher;
-use Vendor\Package\MockControllerSimple AS MockController;
+use Vendor\Package\MockControllerSimple as MockController;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class SimpleDispatcherTest extends TestCase
@@ -59,10 +59,10 @@ class SimpleDispatcherTest extends TestCase
         $parsedRoute = new ParsedRoute("Vendor\Package\MockControllerSimple::nono");
         $dispatcher->handle($parsedRoute);
     }
-
 }
 
 namespace Vendor\Package;
+
 class MockControllerSimple
 {
     public static $index;

--- a/tests/WildcardDispatcherTest.php
+++ b/tests/WildcardDispatcherTest.php
@@ -3,7 +3,7 @@ namespace QuimCalpe\Router\Router\Test;
 
 use QuimCalpe\Router\ParsedRoute;
 use QuimCalpe\Router\WildcardDispatcher;
-use Vendor\Package\MockControllerWildcard AS MockController;
+use Vendor\Package\MockControllerWildcard as MockController;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class WildcardDispatcherTest extends TestCase
@@ -89,6 +89,7 @@ class WildcardDispatcherTest extends TestCase
 }
 
 namespace Vendor\Package;
+
 class MockControllerWildcard
 {
     public static $index;


### PR DESCRIPTION
- Allow named routes to be defined as optional last parameter on
  all ->addXXX methods
- Add `->findURI($name)` method to resolve routes against a name
- Add appropiate tests
- Reformat minor glitches to conform PSR-2
